### PR TITLE
Update webpack config and properly handle client-side routes

### DIFF
--- a/config/webpack/common.loaders.js
+++ b/config/webpack/common.loaders.js
@@ -1,4 +1,4 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = [
     {
@@ -23,7 +23,17 @@ module.exports = [
         ]
     },
     {
-        test: /\.(css|scss)$/,
-        use: ExtractTextPlugin.extract({ use: ['css-loader', 'sass-loader'] })
+        test: /\.(css|scss|sass)$/i,
+        use: [
+            {
+                loader: MiniCssExtractPlugin.loader,
+                options: {
+                    esModule: true,
+                    hmr: false
+                }
+            },
+            'css-loader',
+            'sass-loader'
+        ]
     }
 ];

--- a/config/webpack/common.plugins.js
+++ b/config/webpack/common.plugins.js
@@ -1,0 +1,24 @@
+const baseConfig = require('./common.config');
+const config = require('config');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const webpack = require('webpack');
+
+module.exports = [
+    new MiniCssExtractPlugin({
+        // Options similar to the same options in webpackOptions.output
+        // all options are optional
+        filename: '[name].css',
+        chunkFilename: '[id].css',
+        ignoreOrder: false // Enable to remove warnings about conflicting order
+    }),
+    new HtmlWebpackPlugin({
+        title: 'Fastify React App',
+        template: './template/index.ejs',
+        favicon: './template/favicon.ico'
+    }),
+    new webpack.DefinePlugin({
+        BASE_URL: JSON.stringify(baseConfig.output.publicPath),
+        APP_URL: JSON.stringify(config.get('appUrl'))
+    })
+];

--- a/config/webpack/dev.config.js
+++ b/config/webpack/dev.config.js
@@ -1,9 +1,6 @@
 const baseConfig = require('./common.config');
 const commonLoaders = require('./common.loaders');
-const config = require('config');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const webpack = require('webpack');
+const commonPlugins = require('./common.plugins');
 
 module.exports = Object.assign(baseConfig, {
     mode: 'development',
@@ -11,16 +8,5 @@ module.exports = Object.assign(baseConfig, {
     module: {
         rules: [...commonLoaders]
     },
-    plugins: [
-        new ExtractTextPlugin('[name].bundle.[hash].css'),
-        new HtmlWebpackPlugin({
-            title: 'Fastify React App',
-            template: './template/index.ejs',
-            favicon: './template/favicon.ico'
-        }),
-        new webpack.DefinePlugin({
-            BASE_URL: JSON.stringify(baseConfig.output.publicPath),
-            APP_URL: JSON.stringify(config.get('appUrl'))
-        })
-    ]
+    plugins: [...commonPlugins]
 });

--- a/config/webpack/hmr.config.js
+++ b/config/webpack/hmr.config.js
@@ -1,9 +1,7 @@
-const baseConfig = require('./common.config');
-const config = require('config');
-const commonLoaders = require('./common.loaders');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
+const baseConfig = require('./common.config');
+const commonLoaders = require('./common.loaders');
+const commonPlugins = require('./common.plugins');
 
 module.exports = Object.assign(baseConfig, {
     mode: 'development',
@@ -12,17 +10,5 @@ module.exports = Object.assign(baseConfig, {
     module: {
         rules: [...commonLoaders]
     },
-    plugins: [
-        new ExtractTextPlugin('[name].bundle.[hash].css'),
-        new HtmlWebpackPlugin({
-            title: 'Fastify React App',
-            template: './template/index.ejs',
-            favicon: './template/favicon.ico'
-        }),
-        new webpack.DefinePlugin({
-            BASE_URL: JSON.stringify(baseConfig.output.publicPath),
-            APP_URL: JSON.stringify(config.get('appUrl'))
-        }),
-        new webpack.HotModuleReplacementPlugin()
-    ]
+    plugins: [...commonPlugins, new webpack.HotModuleReplacementPlugin()]
 });

--- a/config/webpack/production.config.js
+++ b/config/webpack/production.config.js
@@ -1,9 +1,7 @@
-const config = require('config');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const webpack = require('webpack');
-const baseConfig = require('./common.config');
 const commonLoaders = require('./common.loaders');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const commonPlugins = require('./common.plugins');
+const baseConfig = require('./common.config');
 
 module.exports = Object.assign(baseConfig, {
     mode: 'production',
@@ -15,19 +13,9 @@ module.exports = Object.assign(baseConfig, {
         nodeEnv: 'production'
     },
     plugins: [
-        new ExtractTextPlugin('[name].bundle.[hash].css'),
-        // Minify CSS
         new webpack.LoaderOptionsPlugin({
             minimize: true
         }),
-        new HtmlWebpackPlugin({
-            title: 'Fastify React App',
-            template: './template/index.ejs',
-            favicon: './template/favicon.ico'
-        }),
-        new webpack.DefinePlugin({
-            BASE_URL: JSON.stringify(baseConfig.output.publicPath),
-            APP_URL: JSON.stringify(config.get('appUrl'))
-        })
+        ...commonPlugins
     ]
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6400,6 +6400,12 @@
                 "path-is-inside": "^1.0.1"
             }
         },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -7145,6 +7151,31 @@
                 "tiny-warning": "^1.0.2"
             }
         },
+        "mini-css-extract-plugin": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
+            "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.1.0",
+                "normalize-url": "1.9.1",
+                "schema-utils": "^1.0.0",
+                "webpack-sources": "^1.1.0"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                }
+            }
+        },
         "minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7605,6 +7636,18 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
+        },
+        "normalize-url": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+            "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.0.1",
+                "prepend-http": "^1.0.0",
+                "query-string": "^4.1.0",
+                "sort-keys": "^1.0.0"
+            }
         },
         "npm-run-path": {
             "version": "2.0.2",
@@ -8472,6 +8515,16 @@
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "query-string": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+            }
         },
         "querystring": {
             "version": "0.2.0",
@@ -9580,6 +9633,15 @@
                 "flatstr": "^1.0.12"
             }
         },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "^1.0.0"
+            }
+        },
         "source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -9771,6 +9833,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
             "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+            "dev": true
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
             "dev": true
         },
         "string-width": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "start": "node src/server/index.js",
         "start:local": "npm run build:local && npm run start:local-static",
         "start:local-hmr": "nodemon --ignore ./www --ignore ./src/client --exec npm run start",
-        "start:local-static": "DISABLE_HMR=true nodemon --ignore ./www --ignore ./src/client --exec npm run start",
+        "start:local-static": "DISABLE_HMR=true nodemon --ignore ./www-local --ignore ./src/client --exec npm run start",
         "build:local": "rm -rf www-local && npm run build:dev && mv www www-local",
         "build:dev": "webpack --config config/webpack/dev.config.js",
         "build:prod": "webpack --config config/webpack/production.config.js --optimize-minimize"
@@ -63,6 +63,7 @@
         "html-webpack-plugin": "^3.2.0",
         "http-proxy-middleware": "^0.20.0",
         "husky": "^3.1.0",
+        "mini-css-extract-plugin": "^0.9.0",
         "node-sass": "^4.13.0",
         "nodemon": "^2.0.2",
         "prettier": "^1.19.1",

--- a/src/server/withConfiguration/serveWebapp/withProductionConfig.js
+++ b/src/server/withConfiguration/serveWebapp/withProductionConfig.js
@@ -1,6 +1,6 @@
 const config = require('config');
 const fastifyStatic = require('fastify-static');
-
+const fs = require('fs');
 const path = require('path');
 
 const withProductionConfig = (app) => {
@@ -14,7 +14,12 @@ const withProductionConfig = (app) => {
     );
 
     app.register(fastifyStatic, {
+        wildcard: false,
         root: buildLocation
+    });
+
+    app.get(`${config.get('contextRoot')}/*`, (request, response, next) => {
+        response.type('text/html').send(fs.readFileSync(path.resolve(buildLocation, 'index.html')));
     });
 };
 


### PR DESCRIPTION
### Changes:
- Replaced `extract-text-webpack-plugin` with `mini-css-extract-plugin`
- Extracted reused webpack plugins into a shared config
- Updated webapp asset routing to properly handle client-side routes